### PR TITLE
Enable parallel uploads for drag-and-drop

### DIFF
--- a/source/forms/CustomScpExplorer.cpp
+++ b/source/forms/CustomScpExplorer.cpp
@@ -2860,7 +2860,11 @@ bool __fastcall TCustomScpExplorerForm::ExecuteCopyMoveFileOperation(
 
           CopyParam.IncludeFileMask.SetRoots(FileList, Param.TargetDirectory);
 
-          Terminal->CopyToRemote(FileList, Param.TargetDirectory, &CopyParam, Params, NULL);
+          TParallelOperation ParallelOperation(osLocal);
+          TParallelOperation *ParallelPtr =
+            CopyParam.QueueParallel ? &ParallelOperation : NULL;
+          Terminal->CopyToRemote(
+            FileList, Param.TargetDirectory, &CopyParam, Params, ParallelPtr);
           if (Operation == foMove)
           {
             ReloadLocalDirectory();


### PR DESCRIPTION
## Summary
- use `TParallelOperation` when uploading files via drag-and-drop

## Testing
- `git commit -m "Enable parallel upload on drag-and-drop"`


------
https://chatgpt.com/codex/tasks/task_e_687598bb8d988332b68156009d683005